### PR TITLE
Add meaningful device info.

### DIFF
--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.util import Throttle
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
@@ -183,13 +183,15 @@ class Component(Entity):
         }
 
     @property
-    def device_info(self) -> dict:
-        """I can't remember why this was needed :D"""
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "manufacturer": DOMAIN,
-        }
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            name=self.name,
+            manufacturer="pixolus GmbH",
+            suggested_area=self._meter_details.get("location_in_building"),
+            configuration_url=f"https://pixometer.io/portal/#/meters/{self._meter_details.get('resource_id')}/edit",
+        )
 
     @property
     def unit(self) -> int:

--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -193,7 +193,7 @@ class Component(Entity):
         """Return the device info."""
         name = self._meter_details.get("label")
         if name == "" or name is None:
-            name = self._meter_details.get("location_in_building")
+            name = f"{NAME} {self._meter_details.get('location_in_building').replace('-', '_')}"
         return DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
             name=name,

--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -165,9 +165,15 @@ class Component(Entity):
             f"{NAME} {self._meter_details.get('location_in_building').replace('-', '_')}"
         )
 
+
     @property
-    def name(self) -> str:  
-        return self.unique_id
+    def has_entity_name(self) -> bool:
+        return True
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return None
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -185,9 +185,12 @@ class Component(Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        name = self._meter_details.get("label")
+        if name == "" or name is None:
+            name = self._meter_details.get("location_in_building")
         return DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
-            name=self.name,
+            name=name,
             manufacturer="pixolus GmbH",
             suggested_area=self._meter_details.get("location_in_building"),
             configuration_url=f"https://pixometer.io/portal/#/meters/{self._meter_details.get('resource_id')}/edit",


### PR DESCRIPTION
This PR adds device information which shows up in the device page in Home Assistant, including a link to each sensor's configuration page at pixometer.io.
This configuration page of the the pixometer.io portal allows to set labels ("Kurzbezeichnung") for each sensor. While these labels don't show up in the free Android app, they do show up in the API.

If available, this PR uses these labels as the device name. If no labels have been set, this PR will fall back to the previous naming scheme based on the location (which is the only attribute show in the free Android app).
For the individual sensor entities, this PR changes the naming to meet Home Assistant requirements, which will result in the entity's name to be equal to the device's name:
https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations

This implementation is backwards-compatible: if you are not using labels, the implementation will give the same name as before. If you use a label, it will use that instead.