### PR TITLE
Use label as name

### DIFF
--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -166,8 +166,12 @@ class Component(Entity):
         )
 
     @property
-    def name(self) -> str:  
-        return self.unique_id
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        name = self._meter_details.get("label")
+        if name == "" or name is None:
+            name = self._meter_details.get("location_in_building")
+        return f"{NAME} {name}"
 
     @property
     def extra_state_attributes(self) -> dict:


### PR DESCRIPTION
The pixometer.io portal allows to set labels ("Kurzbezeichnung") for each sensor. While these labels don't show up in the free Android app, they _do_ show up in the API.

This implementation is backwards-compatible: if you are not using labels, the implementation will give the same name as before. If you use a label, it will use that instead.