### PR TITLE
Use resource ID as unique id.

### DIFF
--- a/custom_components/pixometer/sensor.py
+++ b/custom_components/pixometer/sensor.py
@@ -160,10 +160,8 @@ class Component(Entity):
         
     @property
     def unique_id(self) -> str:
-        """Return the name of the sensor."""
-        return (
-            f"{NAME} {self._meter_details.get('location_in_building').replace('-', '_')}"
-        )
+        """Return the unique ID of the sensor."""
+        return self._meter_details.get('resource_id')
 
     @property
     def name(self) -> str:  


### PR DESCRIPTION
Fixes the unique_id to meet Home Assistant requirements:
https://developers.home-assistant.io/docs/entity_registry_index/#unique-id

> An entity is looked up in the registry based on a combination of the platform type (e.g., light), and the integration name (domain) (e.g. hue) and the unique ID of the entity. Entities should not include the domain (e.g., your_integration) and platform type (e.g., light) in their Unique ID as the system already accounts for these identifiers.

Unfortunately, this change is not backwards-compatible: after updating, your pixometer sensors will show up as new sensors since they will have a new unique_id.

However, the current implementation would generate new IDs when changing a pixometer sensor's location, which does not meet Home Assistant requirements for unique_ids.